### PR TITLE
Feat: Adding service status to the relation data bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+
+.idea/

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ from charms.prometheus_k8s.v0.prometheus_scrape import (  # type: ignore
 )
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, MaintenanceStatus, ModelError, WaitingStatus
 from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
@@ -28,6 +28,9 @@ class PrometheusEdgeHubCharm(CharmBase):
         self._container_name = self._service_name = CHARM_NAME
         self._container = self.unit.get_container(CHARM_NAME)
         self.framework.observe(self.on.prometheus_edge_hub_pebble_ready, self._configure)
+        self.framework.observe(
+            self.on.metrics_endpoint_relation_joined, self._on_metrics_endpoint_relation_joined
+        )
         self.framework.observe(self.on.config_changed, self._configure)
         self._service_patcher = KubernetesServicePatch(
             self,
@@ -101,6 +104,30 @@ class PrometheusEdgeHubCharm(CharmBase):
         else:
             self.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()
+
+    def _on_metrics_endpoint_relation_joined(self, event):
+        if not self.unit.is_leader():
+            return
+        self._update_relation_active_status(
+            relation=event.relation, is_active=self._service_is_running
+        )
+
+    def _update_relation_active_status(self, relation, is_active: bool):
+        relation.data[self.unit].update(
+            {
+                "active": str(is_active),
+            }
+        )
+
+    @property
+    def _service_is_running(self) -> bool:
+        if self._container.can_connect():
+            try:
+                self._container.get_service(self._service_name)
+                return True
+            except ModelError:
+                pass
+        return False
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -140,3 +140,12 @@ class TestCharm(unittest.TestCase):
         updated_plan = self.harness.get_container_pebble_plan("prometheus-edge-hub").to_dict()
         self.assertEqual(initial_plan, expected_initial_plan)
         self.assertEqual(updated_plan, expected_final_plan)
+
+    @patch.object(PrometheusEdgeHubCharm, "_on_metrics_endpoint_relation_joined")
+    def test_given_prometheus_edge_hub_operator_charm_when_metrics_endpoint_relation_joined_event_emitted_then_on_metrics_endpoint_relation_joined_function_called(  # noqa: E501
+        self, patched_on_metrics_endpoint_relation_joined
+    ):
+        relation_id = self.harness.add_relation("metrics_endpoint", "prometheus_scrape")
+        self.harness.add_relation_unit(relation_id, "test/0")
+
+        patched_on_metrics_endpoint_relation_joined.assert_called_once()


### PR DESCRIPTION
Publishes the status of the `prometheus-edge-hub` service inside the data bucket of `metrics-endpoint` relation so that the consumers of this relation know the service status.