### PR TITLE
Convert interface name to string to fix mypy warning

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -454,7 +454,7 @@ def _validate_relation_by_interface_and_direction(
     actual_relation_interface = relation.interface_name
     if actual_relation_interface != expected_relation_interface:
         raise RelationInterfaceMismatchError(
-            relation_name, expected_relation_interface, actual_relation_interface
+            relation_name, expected_relation_interface, str(actual_relation_interface)
         )
 
     if expected_relation_role == RelationRole.provides:


### PR DESCRIPTION
# Description

This avoids a possible case where `relation.interface_name` is `None`. 

Alternatively, we could `assert`, or throw a different error if this happens to be `None`, but this seemed like the easiest path forward. Presumably, this shouldn't happen.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I have bumped the version of any required library.
